### PR TITLE
Fixes/update gh actions

### DIFF
--- a/.github/workflows/build-snapshot.yml
+++ b/.github/workflows/build-snapshot.yml
@@ -1,10 +1,10 @@
-name: Build Zepben Linux libraries
+name: Zepben Snapshot Build
 
 on: 
   workflow_dispatch:
     inputs:
-      tag:
-        description: 'Tag to use for lib release'
+      commitID:
+        description: 'Commit or branch to use for lib release'
         required: true
         type: string
 
@@ -26,7 +26,7 @@ jobs:
       - name: Find commit
         id: find-commit
         run: |
-          commit=$(git rev-parse --short ${{ github.event.inputs.tag }})
+          commit=$(git rev-parse --short ${{ github.event.inputs.commitID }})
           echo "::set-output name=commit::$(echo $commit)"
 
   build_linux_x64:

--- a/.github/workflows/build-zepben.yaml
+++ b/.github/workflows/build-zepben.yaml
@@ -56,6 +56,11 @@ jobs:
           mv package/dss-libs.bz2 package/dss-libs-${{ needs.find-commit.outputs.commitID }}.bz2
         shell: bash
 
+      - name: Create artefact
+        uses: actions/upload-artifact@master
+        with:
+          name: ${{ steps.build.outputs.artifactId }}-${{ steps.build.outputs.version }}
+          path: ${{ steps.build.outputs.artifact-path }}
 
 
       - name: Create Release and upload assets
@@ -69,5 +74,5 @@ jobs:
           draft: false
           prerelease: false
           files: |
-           package/dss-libs-${{ needs.find-commit.outputs.commitID }}.bz2
+            package/dss-libs-${{ needs.find-commit.outputs.commitID }}.bz2
         continue-on-error: false

--- a/.github/workflows/build-zepben.yaml
+++ b/.github/workflows/build-zepben.yaml
@@ -59,8 +59,8 @@ jobs:
       - name: Create artefact
         uses: actions/upload-artifact@master
         with:
-          name: ${{ steps.build.outputs.artifactId }}-${{ steps.build.outputs.version }}
-          path: ${{ steps.build.outputs.artifact-path }}
+          name: dss-libs-${{ needs.find-commit.outputs.commitID }}.bz2 
+          path: package/dss-libs-${{ needs.find-commit.outputs.commitID }}.bz2 
 
 
       - name: Create Release and upload assets

--- a/Makefile
+++ b/Makefile
@@ -10,12 +10,9 @@ klu:
 	make -C ../klusolve 
 	cp ../klusolve/lib/linux_x64/libklusolvex.so ${current_dir}/lib/linux_x64/
 
-rust:
-	cd ../learnRust/fun1 && cargo build --release
-	cp ../learnRust/fun1/target/release/libdss_queue.so ${current_dir}/lib/linux_x64/
-
 rmqpush:
 	make -C ./zepben-extensions/ $@
+	cp ./zepben-extensions/src/include/rmqpush.h include/rmqpush.h
 	cp ./zepben-extensions/lib/librmqpush.so lib/linux_x64/
 
 debian: debian-builder rmqpush

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 current_dir:=${CURDIR}
+package_dir:=${CURDIR}/package
 
 targets = alpine debian
 libs = libklusolvex.so libdss_capi.so librmqpush.so
@@ -30,10 +31,11 @@ ci: rmqpush
 	build/build_linux_x64.sh
 
 package: lib/linux_x64/libdss_capi.so 
-	if [ -d package ];  then rm -rf package; fi
+	if [ -d ${package_dir} ];  then rm -rf ${package_dir}; fi
 	mkdir package
-	cd lib/linux_x64/ && cp ${libs} ${current_dir}/package
-	cd ${current_dir}/package && tar cjvf dss-libs.bz2 *
+	cd ${current_dir}/lib/linux_x64/ && cp ${libs} ${package_dir} 
+	cp ${current_dir}/include/rmqpush.h ${package_dir}
+	cd ${package_dir} && tar cjvf dss-libs.bz2 *
 
 runner: dss-runner.c
 	cp zepben-extensions/src/include/rmqpush.h include/rmqpush.h


### PR DESCRIPTION
# Description

Update the release of the libraries:

* Change the name to the common name used in Zepben builds.
* Update makefile to include rmqpush header in the package.