### PR TITLE
Fix bug where logged msg/sec is inaccurate

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,7 +10,7 @@
 * Improved the way we read publish confirms
 
 ### Fixes
-* None.
+* Fixed cosmetic bug where the msg/sec reported in stdout is inaccurate
 
 ### Notes
 * None.

--- a/zepben-extensions/src/rmqpush.c
+++ b/zepben-extensions/src/rmqpush.c
@@ -224,8 +224,9 @@ void publish_rmq_message(amqp_bytes_t msg) {
     // Print rate of RMQ publish every 3 sec or so
     time_t local1;
     time(&local1);
-    if (difftime(local1, rate_timer) > rate_interval) {
-        printf("%d messages confirmed - pushing %f msg/sec\n", last_ack_tag, (double)msg_counter / rate_interval);
+	time_t elapsed = difftime(local1, rate_timer);
+    if (elapsed > rate_interval) {
+        printf("%d messages confirmed - pushing %f msg/sec\n", last_ack_tag, (double)msg_counter / elapsed);
         fflush(stdout);
         msg_counter = 0;
         time(&rate_timer);


### PR DESCRIPTION
# Description

Fixes a cosmetic bug caused by dss_capi dividing the messages sent since the last log by a fixed value, regardless of the length of time actually elapsed since the last log. Because `wait_for_outstanding_messages(500)` often takes a long time to finish when RabbitMQ is under high load, this resulted in exactly 10000 messages for the msg_counter, which when divided by rate_interval (3) results in 3333.33333 being reported as the mps.

# Associated tasks

No blocking nor blocked tasks.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [ ] ~I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~ (tested manually, see images)
- [ ] ~I have commented my code in any hard-to-understand or hacky areas.~
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).
      
### Documentation
- [x] I have updated the changelog.
- [ ] ~I have updated any documentation required for these changes.~

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members if so.

No breaking changes.

# Screenshots

Remove this section if the change cannot be shown through screenshots. Frontend changes should mostly include this section.
Screenshots can be copy-pasted into Github textboxes and a link will automatically be generated.
Remove this text if you choose to use this section.

| Before | After |
| --- | --- |
| ![image](https://github.com/zepben/dss_capi/assets/19983470/809e66ea-ad1f-4ae4-a27a-52c1bea93938) | ![image (1)](https://github.com/zepben/dss_capi/assets/19983470/c6fee41a-3f40-416c-a0f3-c51d12df4d25) |