### PR TITLE
Don't check for the released tags when updating the changelog

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Update version for release
         id: check
         run: |
-          build/update-changelog.sh $VERSION release
+          build/update-changelog.sh release
         shell: bash
         continue-on-error: false
 

--- a/.github/workflows/build-snapshot.yml
+++ b/.github/workflows/build-snapshot.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Update version for snapshot release
         id: check
         run: |
-          build/update-changelog.sh $VERSION snapshot
+          build/update-changelog.sh snapshot
         shell: bash
         continue-on-error: false
 

--- a/build/update-changelog.sh
+++ b/build/update-changelog.sh
@@ -2,19 +2,6 @@
 
 changelog=./changelog.md
  
-check_tag_exists() {
-  version=${1:? 'Version variable is missing.'}
-  echo "Checking remote tags if version exists..."
-  git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
-  git fetch --tags origin
-  old_tag=$(git tag -l | grep "^$version$" || true)
-  tag=$(git tag -l | grep "^v$version$" || true)
-  if [[ ! -z $tag || ! -z $old_tag ]]; then
-      echo "Tag for this version already exists"
-      exit 1
-  fi
-}
-
 stage_file() {
   file=$1
   if [[ ! -z $file ]]; then
@@ -26,9 +13,6 @@ stage_file() {
   fi
 }
 
-# Check that the provided tag doesn't exist yet
-check_tag_exists $1
-
 # Check out the release branch for changes
 git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
 git fetch --all
@@ -38,16 +22,16 @@ if [[ ! -z $(git branch -a | grep remotes/origin/release) ]]; then
 fi
 git checkout -b release
 
-if [ "$2" = "snapshot" ]; then
+if [ "$1" = "snapshot" ]; then
     echo "SNAPSHOT"
     new_snapshot=$(echo "$version" | sed -e "s/.*-zepben//g")
     new_version=$(echo "$version" | sed -e "s/zepben.*/zepben$(($new_snapshot+1))/g")
-elif [ "$2" = "release" ]; then
+elif [ "$1" = "release" ]; then
     echo "RELEASE"
     new_minor=$(echo $version | sed -e "s/-.*//g" | cut -f4 -d.)
     new_version=$(echo $version | sed -E "s/[[:digit:]]+-zepben/$(($new_minor+1))-zepben/")
 else 
-    echo "Unsupported mode: '$2'"
+    echo "Unsupported mode: '$1'"
 fi
 
 echo "Updating changelog to [$new_version]..."

--- a/changelog.md
+++ b/changelog.md
@@ -10,7 +10,7 @@
 * None.
 
 ### Fixes
-* None.
+* Update-changelog.sh doesn't check the released tag anymore, all flows fixed accordingly.
 
 ### Notes
 * None.


### PR DESCRIPTION
# Description

`update-changelog.sh` is run after creating a release and as such should *not* check for the existence of the $VERSION tag (as the release will always create it). 

# Test Steps

This should fix running (snapshot) releases 

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
~- [ ] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~
~- [ ] I have commented my code in any hard-to-understand or hacky areas.~
~- [ ] I have handled all new warnings generated by the compiler or IDE.~
- [x] I have rebased onto the target branch (usually main).

### Documentation
- [x] I have updated the changelog.
~- [ ] I have updated any documentation required for these changes.~

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members if so.