### PR TITLE
[DEV-3842] Update EnergyMeters to record PVSystem generation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@
   * `int disconnect_rabbitmq()` &rarr; `void disconnect_from_stream()`.
   * Removed `int wait_for_outstanding_messages()`. `void disconnect_from_stream()` ensures all outstanding messages are
     sent before closing the connection.
+* PVSystem generation is now recorded by EnergyMeter's.
 
 ### New Features
 * OpenDSS reports are now sent to a RabbitMQ stream rather than a classic queue, improving throughput.

--- a/src/Meters/EnergyMeter.pas
+++ b/src/Meters/EnergyMeter.pas
@@ -444,6 +444,7 @@ uses
     MemoryMap_Lib,
     DSSHelper,
     DSSObjectHelper,
+    PVSystem,
     TypInfo;
 
 type
@@ -1272,6 +1273,7 @@ procedure TEnergyMeterObj.TakeSample;
 var
     i, j, idx: Integer;
 
+    S,
     S_Local,
     S_Totallosses,
     S_LoadLosses,
@@ -1291,6 +1293,7 @@ var
     PCelem: TPCElement;
     pLoad: TLoadobj;
     pGen: TGeneratorObj;
+    pPVSystem: TPVSystemObj;
    // doubles
     MaxExcesskWNorm,
     MaxExcesskWEmerg,
@@ -1477,6 +1480,13 @@ begin
                 begin
                     pGen := PCElem as TGeneratorObj;
                     Accumulate_Gen(pGen, TotalGenkW, TotalGenkvar);
+                end;
+                PVSYSTEM_ELEMENT:
+                begin
+                   pPVSystem := PCElem as TPVSystemObj;
+                   S := -pPVSystem.Power[1] * 0.001;
+                   TotalGenkW := TotalGenkW + S.re;
+                   TotalGenkvar := TotalGenkvar + S.im;
                 end;
             else
                 //Ignore other types of PC Elements


### PR DESCRIPTION
# Description

Updates EnergyMeter to add PVSystem generation to `TotalGenkW` and `TotalGenkvar` as per:
https://sourceforge.net/p/electricdss/discussion/861977/thread/05e547ec/

# Associated tasks

- https://github.com/zepben/opendss-model-processor/pull/121

Next to merge:
- https://github.com/zepben/opendss-jvm-executor/pull/13

# Test Steps

- Get an open dss model with Generators and PVSystems.
- Run the executor(+results processor) with the current `libdss_capi.so`. 
- Review the results in the `energy_meters_raw` table. 
          The columns `gen_kwh` and `gen_kvarh` should only contain the generation from the Generators in the model.
- Rerun the model with the new `libdss_capi.so`. 
- `gen_kwh` and `gen_kvarh` columns for the new run should now contain the addition generation from the PVSystems.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [~] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [ ] ~I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [ ] ~I have handled all new warnings generated by the compiler or IDE.~
- [x] I have rebased onto the target branch (usually main).

### Security
When developing applications, use following guidelines for information security considerations:
* Access to applications should be protected with security keys/tokens or usernames and passwords;
* All sessions are encrypted if possible;
* All application input is sanitised before being acted on (ie SQL statements, etc);
* Log messages, and especially client-facing ones, must be handled securely and must not leak credentials information (internal URLs, passwords, tokens).

- [x] I have considered if this change impacts information security and made sure those impacts are handled.

### Documentation
- [x] I have updated the changelog.
- [ ] ~I have updated any documentation required for these changes.~

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members by posting it on the Slack **breaking-changes** channel.

Not for us as we are only using PVSystems for LVStatCom and not generation. 