### PR TITLE
[DEV-9144] Handle RabbitMQ timing out in rmqstream library

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,7 @@
 
 ### Fixes
 * Update-changelog.sh doesn't check the released tag anymore, all flows fixed accordingly.
+* Handle RabbitMQ stream publishes timing out by retrying publishes.
 
 ### Notes
 * None.
@@ -74,4 +75,3 @@
 
 ### Notes
 * None.
-

--- a/zepben-extensions/rmqstream/Cargo.toml
+++ b/zepben-extensions/rmqstream/Cargo.toml
@@ -17,3 +17,4 @@ tokio = { version = "1.49.0", features = ["rt", "rt-multi-thread", "time"] }
 tracing = { version = "0.1.44", features = [] }
 tracing-subscriber = "0.3.22"
 tracing-log = "0.2.0"
+rand = "0.10.1"

--- a/zepben-extensions/rmqstream/Cargo.toml
+++ b/zepben-extensions/rmqstream/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rmqstream"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 
 [lib]
@@ -13,7 +13,7 @@ crate-type = ["staticlib"]
 [dependencies]
 libc = "0.2"
 rabbitmq-stream-client = "0.10.0"
-tokio = { version = "1.49.0", features = ["rt", "rt-multi-thread"] }
+tokio = { version = "1.49.0", features = ["rt", "rt-multi-thread", "time"] }
 tracing = { version = "0.1.44", features = [] }
 tracing-subscriber = "0.3.22"
 tracing-log = "0.2.0"

--- a/zepben-extensions/rmqstream/src/lib.rs
+++ b/zepben-extensions/rmqstream/src/lib.rs
@@ -239,7 +239,7 @@ async fn try_send(
                 delay = delay * 2;
                 retires += 1;
             }
-            Err(e) => error!("Could not send message: {e}"),
+            Err(e) => panic!("Could not send message: {e}"),
         }
     }
 }

--- a/zepben-extensions/rmqstream/src/lib.rs
+++ b/zepben-extensions/rmqstream/src/lib.rs
@@ -1,13 +1,14 @@
+use rabbitmq_stream_client::error::ProducerCloseError;
+use rabbitmq_stream_client::error::ProducerPublishError;
+use rabbitmq_stream_client::types::{Message, ResponseCode};
+use rabbitmq_stream_client::{Environment, NoDedup, Producer};
 use std::ffi::CStr;
 use std::slice;
-use std::time::{Duration, Instant};
-use rabbitmq_stream_client::{Environment, NoDedup, Producer};
-use tracing::{debug, error, info, trace, warn};
-use rabbitmq_stream_client::error::ProducerCloseError;
-use rabbitmq_stream_client::types::{Message, ResponseCode};
 use std::sync::{LazyLock, Mutex};
+use std::time::{Duration, Instant};
 use tokio::runtime::Runtime;
 use tokio::time::sleep;
+use tracing::{debug, error, info, trace, warn};
 
 use crate::logging::initialise_logging;
 
@@ -66,7 +67,9 @@ pub unsafe extern "C" fn connect_to_stream(
     let stream = CStr::from_ptr(_stream).to_string_lossy().to_string();
     let heartbeat = _heartbeat as u32;
 
-    debug!("C params read. Connecting to RabbitMQ stream ({user}@{host}:{port}, stream {stream})...");
+    debug!(
+        "C params read. Connecting to RabbitMQ stream ({user}@{host}:{port}, stream {stream})..."
+    );
 
     let producer = RUNTIME.block_on(async {
         // Retry connection up to 3 times
@@ -96,13 +99,23 @@ pub unsafe extern "C" fn connect_to_stream(
                         Ok(producer) => return producer,
                         Err(e) => {
                             last_error = Some(e.to_string());
-                            warn!("Failed to create producer (attempt {} of {}): {}", retries + 1, max_retries, e);
+                            warn!(
+                                "Failed to create producer (attempt {} of {}): {}",
+                                retries + 1,
+                                max_retries,
+                                e
+                            );
                         }
                     }
-                },
+                }
                 Err(e) => {
                     last_error = Some(e.to_string());
-                    warn!("Connection failed (attempt {} of {}): {}", retries + 1, max_retries, e);
+                    warn!(
+                        "Connection failed (attempt {} of {}): {}",
+                        retries + 1,
+                        max_retries,
+                        e
+                    );
                 }
             }
 
@@ -114,8 +127,7 @@ pub unsafe extern "C" fn connect_to_stream(
 
         panic!(
             "Could not connect to RabbitMQ after {} attempts. Last error: {:?}",
-            max_retries,
-            last_error
+            max_retries, last_error
         );
     });
 
@@ -138,15 +150,22 @@ pub unsafe extern "C" fn disconnect_from_stream() {
                     Err(ProducerCloseError::Close { status: ResponseCode::PublisherDoesNotExist, .. }) => {
                         // Results processor may have already deleted the stream (and consequently, the publisher)
                         // so we handle it gracefully here.
-                        eprintln!("Publisher does not exist (has the stream been deleted?), but the producer has closed anyway.");
+                        warn!("Publisher does not exist (has the stream been deleted?), but the producer has closed anyway.");
                     }
                     Err(e) => panic!("Unexpected error when closing producer: {:?}", e),
                     Ok(_) => (),
                 }
             });
             let total_messages = STATS.lock().unwrap().total_messages;
-            let seconds_elapsed = STATS.lock().unwrap().start_time.unwrap().elapsed().as_secs_f64();
-            let busy_percent = (STATS.lock().unwrap().busy_time.as_secs_f64() / seconds_elapsed) * 100.0;
+            let seconds_elapsed = STATS
+                .lock()
+                .unwrap()
+                .start_time
+                .unwrap()
+                .elapsed()
+                .as_secs_f64();
+            let busy_percent =
+                (STATS.lock().unwrap().busy_time.as_secs_f64() / seconds_elapsed) * 100.0;
             let msg_per_sec = total_messages as f64 / seconds_elapsed;
             let bits_per_sec = 8.0 * STATS.lock().unwrap().total_bytes as f64 / seconds_elapsed;
             info!(
@@ -168,28 +187,15 @@ pub unsafe extern "C" fn stream_out_message(
         let msg_u8_ptr = msg_ptr as *const u8;
         let msg_bytes = slice::from_raw_parts(msg_u8_ptr, msg_len).to_vec();
         RUNTIME.block_on(async move {
+            let message: Message = Message::builder().body(msg_bytes).build();
+
             if confirm {
-                producer.send_with_confirm(
-                    Message::builder().body(msg_bytes).build()
-                ).await.expect("Could not send message!");
-            }
-            else {
-                producer
-                    .send(
-                        Message::builder().body(msg_bytes).build(),
-                        move |res| async move {
-                            match res {
-                                Ok(_) => {
-                                    trace!("Streamed a message containing {} bytes.", msg_len)
-                                }
-                                Err(e) => {
-                                    error!("Could not confirm message! Full error: {}", e)
-                                }
-                            }
-                        },
-                    )
-                    .await
-                    .expect("Could not push message to output queue!");
+                try_send(message, |message| async {
+                    producer.send_with_confirm(message).await.map(|_| ())
+                })
+                .await;
+            } else {
+                try_send(message, |message| producer.send(message, |_| async {})).await;
             }
         });
         STATS.lock().unwrap().busy_time += busy_start.elapsed();
@@ -197,5 +203,39 @@ pub unsafe extern "C" fn stream_out_message(
         STATS.lock().unwrap().total_bytes += msg_len;
     } else {
         error!("Not connected to a RabbitMQ stream!");
+    }
+}
+
+const SEND_MAX_RETRIES: usize = 3;
+const SEND_BACKOFF_DELAY: Duration = Duration::from_secs(5);
+
+/// Try to send a message with the given `send` closure. If the `send` closure
+/// returns `ProducerPublishError::Timeout` then the send is retried.
+///
+/// The message will be retried with exponential backoff
+async fn try_send(
+    message: Message,
+    send: impl AsyncFn(Message) -> Result<(), ProducerPublishError>,
+) {
+    let mut delay: Duration = SEND_BACKOFF_DELAY;
+    let mut retires = 0;
+
+    while retires < SEND_MAX_RETRIES {
+        match send(message.clone()).await {
+            Ok(_) => trace!(
+                "Streamed a message containing {} bytes",
+                message.data().map_or(0, |data| data.len())
+            ),
+            Err(ProducerPublishError::Timeout) => {
+                warn!(
+                    "Timeout bublishing message. Waiting {}ms before retrying",
+                    delay.as_millis()
+                );
+                sleep(delay).await;
+                delay = delay * 2;
+                retires += 1;
+            }
+            Err(e) => error!("Could not send message: {e}"),
+        }
     }
 }

--- a/zepben-extensions/rmqstream/src/lib.rs
+++ b/zepben-extensions/rmqstream/src/lib.rs
@@ -192,10 +192,14 @@ pub unsafe extern "C" fn stream_out_message(
 
             if confirm {
                 try_send(message, |message| async {
-                    producer.send_with_confirm(message).await.map(|_| ())
+                    let result = producer.send_with_confirm(message).await;
+                    result.map(|_| ()) // replace the confirmation status with
                 })
                 .await;
             } else {
+                // the callback `cb` passed to `send` is invoked on the confirmation of the message send.
+                // since we dont need the confirmation callback for anything, we pass a noop closure
+
                 try_send(message, |message| producer.send(message, |_| async {})).await;
             }
         });

--- a/zepben-extensions/rmqstream/src/lib.rs
+++ b/zepben-extensions/rmqstream/src/lib.rs
@@ -2,6 +2,7 @@ use rabbitmq_stream_client::error::ProducerCloseError;
 use rabbitmq_stream_client::error::ProducerPublishError;
 use rabbitmq_stream_client::types::{Message, ResponseCode};
 use rabbitmq_stream_client::{Environment, NoDedup, Producer};
+use rand::random_range;
 use std::ffi::CStr;
 use std::slice;
 use std::sync::{LazyLock, Mutex};
@@ -60,11 +61,11 @@ pub unsafe extern "C" fn connect_to_stream(
     }
 
     debug!("Reading in parameters from C types...");
-    let host = CStr::from_ptr(_host).to_string_lossy().to_string();
+    let host = unsafe { CStr::from_ptr(_host).to_string_lossy().to_string() };
     let port = _port as u16;
-    let user = CStr::from_ptr(_user).to_string_lossy().to_string();
-    let pass = CStr::from_ptr(_pass).to_string_lossy().to_string();
-    let stream = CStr::from_ptr(_stream).to_string_lossy().to_string();
+    let user = unsafe { CStr::from_ptr(_user).to_string_lossy().to_string() };
+    let pass = unsafe { CStr::from_ptr(_pass).to_string_lossy().to_string() };
+    let stream = unsafe { CStr::from_ptr(_stream).to_string_lossy().to_string() };
     let heartbeat = _heartbeat as u32;
 
     debug!(
@@ -185,7 +186,7 @@ pub unsafe extern "C" fn stream_out_message(
     if let Some(producer) = &mut *PRODUCER.lock().unwrap() {
         let busy_start = Instant::now();
         let msg_u8_ptr = msg_ptr as *const u8;
-        let msg_bytes = slice::from_raw_parts(msg_u8_ptr, msg_len).to_vec();
+        let msg_bytes = unsafe { slice::from_raw_parts(msg_u8_ptr, msg_len).to_vec() };
         RUNTIME.block_on(async move {
             let message: Message = Message::builder().body(msg_bytes).build();
 
@@ -227,15 +228,23 @@ async fn try_send(
                 message.data().map_or(0, |data| data.len())
             ),
             Err(ProducerPublishError::Timeout) => {
+                let actual_delay = jittered_delay(delay);
+
                 warn!(
-                    "Timeout bublishing message. Waiting {}ms before retrying",
-                    delay.as_millis()
+                    "Timeout publishing message. Waiting {}ms before retrying",
+                    actual_delay.as_millis()
                 );
-                sleep(delay).await;
+
+                sleep(actual_delay).await;
                 delay = delay * 2;
                 retires += 1;
             }
             Err(e) => error!("Could not send message: {e}"),
         }
     }
+}
+
+/// Return the given delay, with 50% random jitter applied
+fn jittered_delay(delay: Duration) -> Duration {
+    random_range(Duration::ZERO..delay) - (delay / 2)
 }


### PR DESCRIPTION
# Description

Update the rmqstream rust library to handle retrying for timing out when sending messages.

# Associated tasks

None

# Test Steps

None

# Checklist

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [x] ~I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).

### Security
When developing applications, use following guidelines for information security considerations:
* Access to applications should be protected with security keys/tokens or usernames and passwords;
* All sessions are encrypted if possible;
* All application input is sanitised before being acted on (ie SQL statements, etc);
* Log messages, and especially client-facing ones, must be handled securely and must not leak credentials information (internal URLs, passwords, tokens).

- [x] I have considered if this change impacts information security and made sure those impacts are handled.

### Documentation
- [x] I have updated the changelog.
- [x] ~I have updated any documentation required for these changes.~

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members by posting it on the Slack **breaking-changes** channel.

None
