### PR TITLE
[DEV-9671] expose transformer kva ratings

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,7 +9,7 @@
   * `int disconnect_rabbitmq()` &rarr; `void disconnect_from_stream()`.
   * Removed `int wait_for_outstanding_messages()`. `void disconnect_from_stream()` ensures all outstanding messages are
     sent before closing the connection.
-* PVSystem generation is now recorded by EnergyMeter's.
+* PVSystem generation is now recorded by EnergyMeters.
 
 ### New Features
 * OpenDSS reports are now sent to a RabbitMQ stream rather than a classic queue, improving throughput.

--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@
 
 ### New Features
 * OpenDSS reports are now sent to a RabbitMQ stream rather than a classic queue, improving throughput.
+* Added `Transformers_Get_NormHkVA` and `Transformers_Get_EmergHkVA`, plus context API and C++ wrapper declarations, for reading transformer normal and emergency kVA ratings.
 
 ### Enhancements
 * None.

--- a/include/dss_capi.h
+++ b/include/dss_capi.h
@@ -5980,6 +5980,16 @@ extern "C" {
     DSS_CAPI_DLL double Transformers_Get_kVA(void);
 
     /*! 
+    Normal kVA rating for the active Transformer.
+    */
+    DSS_CAPI_DLL double Transformers_Get_NormHkVA(void);
+
+    /*! 
+    Emergency kVA rating for the active Transformer.
+    */
+    DSS_CAPI_DLL double Transformers_Get_EmergHkVA(void);
+
+    /*! 
     Active Winding maximum tap in per-unit.
     */
     DSS_CAPI_DLL double Transformers_Get_MaxTap(void);

--- a/include/dss_capi_ctx.h
+++ b/include/dss_capi_ctx.h
@@ -5777,6 +5777,16 @@ extern "C" {
     DSS_CAPI_DLL double ctx_Transformers_Get_kVA(void* ctx);
 
     /*! 
+    Normal kVA rating for the active Transformer.
+    */
+    DSS_CAPI_DLL double ctx_Transformers_Get_NormHkVA(void* ctx);
+
+    /*! 
+    Emergency kVA rating for the active Transformer.
+    */
+    DSS_CAPI_DLL double ctx_Transformers_Get_EmergHkVA(void* ctx);
+
+    /*! 
     Active Winding maximum tap in per-unit.
     */
     DSS_CAPI_DLL double ctx_Transformers_Get_MaxTap(void* ctx);

--- a/include/dss_classic.hpp
+++ b/include/dss_classic.hpp
@@ -6750,6 +6750,24 @@ using namespace dss::capi;
         }
 
         /// 
+        /// Normal kVA rating for the active Transformer.
+        /// 
+        double NormHkVA() // getter
+        {
+            APIUtil::ErrorChecker error_checker(api_util);
+            return ctx_Transformers_Get_NormHkVA(ctx);
+        }
+
+        /// 
+        /// Emergency kVA rating for the active Transformer.
+        /// 
+        double EmergHkVA() // getter
+        {
+            APIUtil::ErrorChecker error_checker(api_util);
+            return ctx_Transformers_Get_EmergHkVA(ctx);
+        }
+
+        /// 
         /// Complex array of voltages for active winding
         /// 
         template <typename VectorT=Eigen::Matrix<double, Eigen::Dynamic, 1>>

--- a/src/CAPI/CAPI_Transformers.pas
+++ b/src/CAPI/CAPI_Transformers.pas
@@ -12,6 +12,8 @@ function Transformers_Get_First(): Integer; CDECL;
 function Transformers_Get_IsDelta(): TAPIBoolean; CDECL;
 function Transformers_Get_kV(): Double; CDECL;
 function Transformers_Get_kVA(): Double; CDECL;
+function Transformers_Get_NormHkVA(): Double; CDECL;
+function Transformers_Get_EmergHkVA(): Double; CDECL;
 function Transformers_Get_MaxTap(): Double; CDECL;
 function Transformers_Get_MinTap(): Double; CDECL;
 function Transformers_Get_Name(): PAnsiChar; CDECL;
@@ -201,6 +203,28 @@ begin
     if (elem.ActiveWinding > 0) and 
        (elem.ActiveWinding <= elem.NumWindings) then
         Result := elem.WdgKVA[elem.ActiveWinding];
+end;
+//------------------------------------------------------------------------------
+function Transformers_Get_NormHkVA(): Double; CDECL;
+var
+    elem: TObj;
+begin
+    Result := 0.0;
+    if not _activeObj(DSSPrime, elem) then
+        Exit;
+
+    Result := elem.NormMaxHkVA;
+end;
+//------------------------------------------------------------------------------
+function Transformers_Get_EmergHkVA(): Double; CDECL;
+var
+    elem: TObj;
+begin
+    Result := 0.0;
+    if not _activeObj(DSSPrime, elem) then
+        Exit;
+
+    Result := elem.EmergMaxHkVA;
 end;
 //------------------------------------------------------------------------------
 function Transformers_Get_MaxTap(): Double; CDECL;

--- a/src/dss_capi.lpr
+++ b/src/dss_capi.lpr
@@ -1406,6 +1406,8 @@ exports
     Transformers_Get_IsDelta,
     Transformers_Get_kV,
     Transformers_Get_kVA,
+    Transformers_Get_NormHkVA,
+    Transformers_Get_EmergHkVA,
     Transformers_Get_MaxTap,
     Transformers_Get_MinTap,
     Transformers_Get_Name,


### PR DESCRIPTION
# Description

Exposes transformer kVA ratings (normal and emergency) to be used in outputting thermal results for transformers in asset-level thermal summary table.

# Associated tasks

Tasks this is blocking:
- https://github.com/zepben/opendss-model-processor/pull/198

# Test Steps

With the downstream change, Run a work package and ensure that the asset-level thermal results for transformer have the correct normal and emergency kVA ratings.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
~- [ ] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~
~- [ ] I have commented my code in any hard-to-understand or hacky areas.~
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).

### Security
When developing applications, use following guidelines for information security considerations:
* Access to applications should be protected with security keys/tokens or usernames and passwords;
* All sessions are encrypted if possible;
* All application input is sanitised before being acted on (ie SQL statements, etc);
* Log messages, and especially client-facing ones, must be handled securely and must not leak credentials information (internal URLs, passwords, tokens).

- [x] I have considered if this change impacts information security and made sure those impacts are handled.

### Documentation
- [x] I have updated the changelog.
~- [ ] I have updated any documentation required for these changes.~

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members by posting it on the Slack **breaking-changes** channel.

No breaking changes.
